### PR TITLE
[MASTER] SBI-7786

### DIFF
--- a/hydra-data/pom.xml
+++ b/hydra-data/pom.xml
@@ -71,7 +71,7 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-all</artifactId>
-      <version>4.0.19.Final</version>
+      <version>${hydra.dep.io.netty.version}</version>
     </dependency>
     <dependency>
       <groupId>commons-codec</groupId>

--- a/hydra-main/pom.xml
+++ b/hydra-main/pom.xml
@@ -170,7 +170,7 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-all</artifactId>
-      <version>4.0.19.Final</version>
+      <version>${hydra.dep.io.netty.version}</version>
     </dependency>
     <dependency>
       <groupId>com.sleepycat</groupId>

--- a/hydra-store/pom.xml
+++ b/hydra-store/pom.xml
@@ -47,11 +47,6 @@
       <version>1.0.1</version>
     </dependency>
     <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-buffer</artifactId>
-      <version>4.0.19.Final</version>
-    </dependency>
-    <dependency>
       <groupId>com.ning</groupId>
       <artifactId>compress-lzf</artifactId>
       <version>${hydra.dep.compress.compress-lzf.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -78,8 +78,8 @@
     <hydra.dep.compress.snappy-java.version>1.0.4.1</hydra.dep.compress.snappy-java.version>
     <hydra.dep.compress.lzma-java.version>1.2</hydra.dep.compress.lzma-java.version>
     <hydra.dep.compress.apache.commons-compress.version>1.6</hydra.dep.compress.apache.commons-compress.version>
-
     <hydra.dep.sleepycat.je.version>5.0.73</hydra.dep.sleepycat.je.version>
+    <hydra.dep.io.netty.version>4.0.25.Final</hydra.dep.io.netty.version>
   </properties>
 
   <build>
@@ -221,6 +221,11 @@
       <artifactId>org.eclipse.jgit</artifactId>
       <version>3.0.0.201306101825-r</version>
     </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-all</artifactId>
+       <version>${hydra.dep.io.netty.version}</version>
+    </dependency>
 
     <!-- addthis oss -->
     <dependency>
@@ -244,6 +249,44 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.addthis</groupId>
+        <artifactId>codec</artifactId>
+        <version>${hydra.dep.codec.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-buffer</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>com.addthis</groupId>
+        <artifactId>meshy</artifactId>
+        <version>${hydra.dep.meshy.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>io.netty</groupId>
+            <artifactId>netty</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>com.addthis</groupId>
+        <artifactId>muxy</artifactId>
+        <version>${hydra.dep.muxy.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-buffer</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <reporting>
     <plugins>


### PR DESCRIPTION
@Albert-Coding 
Update io.netty dependencies to netty-all 4.0.25.Final, including io.netty:netty, io.netty:netty-buffer, io.netty:netty-common and io.netty:netty-all.
